### PR TITLE
Fix 使用stylus时报错

### DIFF
--- a/lib/util/compile-and-write-stylus.js
+++ b/lib/util/compile-and-write-stylus.js
@@ -43,10 +43,10 @@ module.exports = exports = function compileAndWriteStylus( compileOptions, docRo
 
     stylus(content)
         .set('filename', pathname)
-        .set('compress', !!compileOptions.compress)
+        .set('compress', compileOptions && !!compileOptions.compress)
         .set('paths', paths)
         .use(function( style ) {
-            if ('function' === typeof compileOptions.use) {
+            if (compileOptions && 'function' === typeof compileOptions.use) {
                 compileOptions.use( style );
             }
         })


### PR DESCRIPTION
访问`.styl文件`时报错 edp `ERROR` Cannot read property **'compress'** of undefined

大概定位到 [/util/compile-and-write-stylus.js#L46](https://github.com/ecomfe/edp-webserver/blob/1.0.0-dev/lib/util/compile-and-write-stylus.js#L46)

在`.compress`和`.use`处添加了compileOptions 判断，解决问题!!!
