### PR TITLE
修复在添加了paths时less编辑错误的问题

### DIFF
--- a/lib/util/compile-and-write-less.js
+++ b/lib/util/compile-and-write-less.js
@@ -51,6 +51,7 @@ module.exports = exports = function compileAndWriteLess(compileOptions, docRoot,
         require('../util/extend')(
             {},
             {
+                filename: docRoot + pathname,
                 paths: paths,
                 relativeUrls: true
             },


### PR DESCRIPTION
添加`filename`参数可以支持自定义`paths`参数的编译。对不使用`paths`参数的配置无影响。
