### PR TITLE
content-type大小写不一致

### DIFF
--- a/lib/handlers/php.js
+++ b/lib/handlers/php.js
@@ -190,7 +190,7 @@ module.exports = exports = function(opt_handler, opt_suffix, opt_forwardPathName
 
             for(var i in headers) {
                 if (headers.hasOwnProperty(i)) {
-                    context.header[i] = headers[i];
+                    context.header[i.toLowerCase()] = headers[i];
                 }
             }
 


### PR DESCRIPTION
php生成的头部为`Content-type`，系统默认为小写，统一转换成小写，
不然livereload处理的时候会检测不到html文本类型。