### PR TITLE
使用完整文件路径作为filename

### DIFF
--- a/lib/handlers/babel.js
+++ b/lib/handlers/babel.js
@@ -61,7 +61,7 @@ module.exports = exports = function babel(babelOptions, options) {
             usedBabelOptions.sourceMaps = 'both';
         }
         // 这里必须给一个和处理的文件名不一样的
-        usedBabelOptions.filename = context.request.pathname.replace(/\.(\w+)$/, '.raw.$1');
+        usedBabelOptions.filename = filePath.replace(/\.(\w+)$/, '.raw.$1');
         context.header['content-type'] = 'text/javascript; charset=utf-8';
 
         var stat = null;


### PR DESCRIPTION
以配合babel 6.x查找插件的逻辑