### PR TITLE
使用全路径及增加 `?raw` 参数

### DIFF
--- a/lib/handlers/babel.js
+++ b/lib/handlers/babel.js
@@ -52,8 +52,10 @@ module.exports = exports = function babel(babelOptions, options) {
         else if (usedBabelOptions.sourceMaps === 'inline') {
             usedBabelOptions.sourceMaps = 'both';
         }
-        // 这里必须给一个和处理的文件名不一样的
-        usedBabelOptions.filename = context.request.pathname.replace(/\.(\w+)$/, '.raw.$1');
+
+        // 使用全路径以配合 babel 6.x 查找插件的逻辑
+        // 增加 `?raw` 参数以方便 devtool 调试
+        usedBabelOptions.filename = filePath.replace(/\.(\w+)$/, '.$1?raw');
         context.header['content-type'] = 'text/javascript; charset=utf-8';
 
         var stat = null;


### PR DESCRIPTION
见 https://github.com/ecomfe/edp-test/issues/18

1. 使用全路径以配合 babel 6.x 查找插件的逻辑
2. 增加 `?raw` 参数以方便 devtool 调试