### PR TITLE
修正与其它处理器同时使用时可能会错误读取前面生成的缓存的问题

### DIFF
--- a/lib/util/process-and-write-css.js
+++ b/lib/util/process-and-write-css.js
@@ -47,13 +47,15 @@ function handleResult(css, context) {
  * @param {Object} context 请求环境对象
  */
 module.exports = exports = function processAndWriteCSS(processOptions, docRoot, pathname, content, context) {
-    var filePath = path.join(docRoot, pathname);
-    var css = filecache.check(filePath);
-    if (css) {
-        edp.log.info('Read From Cache: ' + pathname);
-        context.header['content-type'] = mimeType.css;
-        context.content = css;
-        return;
+    var filePath = path.join(docRoot, pathname).replace(/(\.\w+)$/, '.postcss$1');
+    if (!processOptions.disableCache) {
+        var css = filecache.check(filePath);
+        if (css) {
+            edp.log.info('Read From Cache: ' + pathname);
+            context.header['content-type'] = mimeType.css;
+            context.content = css;
+            return;
+        }
     }
 
     context.stop();


### PR DESCRIPTION
比如 `less` 这个 handler 生成过缓存了，因为文件名没变，这里就会直接返回之前的缓存。为 `postcss` 这里的缓存修改一下文件名。同时增加一个禁用缓存的选项，因为 `postcss` 无法知道插件依赖了什么别的文件，如果外部文件修改会影响本文件内容的话，需要禁用掉缓存。