### PR TITLE
把HTTPS处理逻辑挪到默认值填充完毕之后

### DIFF
--- a/lib/handlers/proxy.js
+++ b/lib/handlers/proxy.js
@@ -17,20 +17,6 @@ var https = require('https');
  * @return {Function}
  */
 module.exports = exports = function proxy(hostname, port, requestHeaders) {
-    // http or https
-    var agent = /^https:/.test(hostname) ? https : http;
-    var index = hostname.indexOf('://');
-    if (index !== -1) {
-        hostname = hostname.substring(index + 3);
-    }
-    else if (parseInt(port, 10) === 443) {
-        // 如果hostname没有https或者http开头，则如果port是443，使用https
-        agent = https;
-    }
-
-    // 设置默认端口
-    port = port || (agent === https ? 443 : 80);
-
     return function (context) {
         var request = context.request;
         var proxyMap = context.conf.proxyMap;
@@ -53,6 +39,21 @@ module.exports = exports = function proxy(hostname, port, requestHeaders) {
                 edp.log.warn('Can not find matched host for %s', chalk.red(host));
                 return;
             }
+        }
+
+        // http or https
+        var agent = /^https:/.test(hostname) ? https : http;
+
+        // 设置默认端口
+        port = port || (agent === https ? 443 : 80);
+
+        var index = hostname.indexOf('://');
+        if (index !== -1) {
+            hostname = hostname.substring(index + 3);
+        }
+        else if (parseInt(port, 10) === 443) {
+            // 如果hostname没有https或者http开头，则如果port是443，使用https
+            agent = https;
         }
 
         context.stop();


### PR DESCRIPTION
直接调 `hostname.indexOf('://')` 可能直接报错了。