### PR TITLE
增加自动打开浏览器功能

### DIFF
--- a/cli/webserver.js
+++ b/cli/webserver.js
@@ -75,7 +75,8 @@ cli.options = [
     'proxy:',
     'port:',
     'config:',
-    'document-root:'
+    'document-root:',
+    'navigator:'
 ];
 
 /**
@@ -84,6 +85,7 @@ cli.options = [
 cli.main = function (args, opts) {
     var proxy = opts.proxy;
     var port = opts.port;
+    var navigator = opts.navigator;
     var docRoot = opts['document-root'];
     var conf = opts.config;
 
@@ -102,6 +104,10 @@ cli.main = function (args, opts) {
 
     if (port) {
         conf.port = port;
+    }
+
+    if (navigator) {
+        conf.navigator = navigator;
     }
 
     if (proxy) {

--- a/lib/start.js
+++ b/lib/start.js
@@ -14,6 +14,7 @@ var https = require('https');
 var http2 = require('http2');
 var connect = require('connect');
 var edp = require('edp-core');
+var launcher = require( 'edp-browser-launcher2' );
 
 /**
  * 服务器配置
@@ -34,6 +35,7 @@ module.exports = function (config) {
 
     var port = config.port || 80;
     var protocol = config.protocol || 'http';
+    var navigator = config.navigator;
     var documentRoot = config.documentRoot;
     var injectResource = config.injectResource || config.injectRes;
     injectResource && injectResource(require('./resource'));
@@ -68,6 +70,43 @@ module.exports = function (config) {
 
     edp.log.info('EDP WebServer start, %s', accessUrl);
     edp.log.info('root = [%s], listen = [%s] ', documentRoot, port);
+
+    if (navigator) {
+        launcher.detect(function(available) {
+            if (available && available.length) {
+                var browsers = [];
+
+                while (available.length) {
+                    var browser = available.shift();
+                    browsers.push(browser.name);
+                }
+
+                if (typeof navigator !== 'string' || browsers.indexOf(navigator) < 0) {
+                    if (~browsers.indexOf('chrome')) {
+                        navigator = 'chrome';
+                    } else {
+                        navigator = browsers[0];
+                    }
+                }
+
+                launcher(function(err, launch) {
+                    if (err) {
+                        return console.error(err);
+                    }
+
+                    launch(accessUrl, navigator, function(err, instance) {
+                        if (err) {
+                            return console.error(err);
+                        }
+
+                        edp.log.info('Instance started with PID: %s', instance.pid);
+                    });
+                });
+            } else {
+                return console.error('Not found available browser')
+            }
+        });
+    }
 
     return server;
 };

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "coffee-script": "~1.9.2",
     "connect": "~3.3.5",
     "connect-logger": "0.0.1",
+    "edp-browser-launcher2": "^0.4.5",
     "edp-core": "~1.0.12",
     "handlebars": "~3.0.3",
     "html2js": "~0.2.0",


### PR DESCRIPTION
使用的 `edp-browser-launcher2`
通过 --navigator设置指定浏览器，默认chrome浏览器，
没有安装chrome则会采用系统安装的其他浏览器
`edp webserver --navigator`
`edp webserver --navigator=ie`
